### PR TITLE
feat(odoo): adds 16.0 support for /websocket, add a post install hook to install the db

### DIFF
--- a/charts/odoo/Chart.yaml
+++ b/charts/odoo/Chart.yaml
@@ -18,4 +18,4 @@ maintainers:
 # YYYYMMVERSION (i.e. 20220701 for the 1st version in July 2022, 20220702 for
 # the 2nd in July 2022, 20220801 for the 1st version in August 2022, etc.)
 # as the patch part of the version string.
-version: 1.0.20230104
+version: 1.0.20230301

--- a/charts/odoo/README.md
+++ b/charts/odoo/README.md
@@ -2,7 +2,7 @@
 
 An opinionated "Bring Your Own Image" Doodba (Odoo) Helm chart for Kubernetes
 
-![Version: 1.0.20230104](https://img.shields.io/badge/Version-1.0.20230104-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 1.0.20230301](https://img.shields.io/badge/Version-1.0.20230301-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Opinionated odoo Bring Your Own Image chart designed for running [Doodba](https://github.com/Tecnativa/doodba) based Odoo deployments with Glodo defaults.
 
@@ -134,6 +134,7 @@ $ helm install my-release glodo/odoo -f ./helm-values.yaml
 | web.ingress.compress | bool | `false` | Automatically create a Traefik compress middleware |
 | web.ingress.enabled | bool | `true` | enable Ingress or Traefik IngressRoute creation |
 | web.ingress.entryPoints | list | `["websecure"]` | if type is IngressRoute then the IngressRoute entryPoint, if type is Ingress then it will automatically set the entrypoint annotation |
+| web.ingress.geventPath | string | `"/longpolling/"` | "longpolling" path. Under 16.0 this should be changed for /websocket |
 | web.ingress.hosts | list | `["chart-example.local"]` | if type is Ingress then a list of host names to match, if not using certificate CRD then also used for tls host names |
 | web.ingress.match | string | `"Host(`chart-example.local`)"` | if type is IngressRoute then a string of IngressRoute compatible matches |
 | web.ingress.middlewares | list | `[]` | if type is IngressRoute then Traefik Middlewares, if type is Ingress then it will automatically set Ingress annotations |

--- a/charts/odoo/README.md
+++ b/charts/odoo/README.md
@@ -49,8 +49,10 @@ $ helm install my-release glodo/odoo -f ./helm-values.yaml
 | image.repository | string | `"glodouk/CHANGEME"` | container image |
 | image.tag | string | `""` | container tag |
 | imagePullSecrets | list | `[]` | imagePullSecrets will be propagated to all containers, if set |
+| install.enabled | bool | `false` | enable the pre-install hook to init the db |
+| install.name | string | `"install"` |  |
 | longpolling.affinity | object | `{}` |  |
-| longpolling.config | string | `"[options]\nlimit_memory_soft = 3758096384\nlimit_memory_hard = 4294967296\nlimit_time_cpu = 360\nlimit_time_real = 360\nlimit_time_real_cron = 360\nmax_cron_threads = 0\nworkers = 5\nlongpolling_port = 8072\n"` | through environment variables |
+| longpolling.config | string | `"[options]\nlimit_time_cpu = 360\nlimit_time_real = 360\nlimit_time_real_cron = 360\nmax_cron_threads = 0\nworkers = 4\nlongpolling_port = 8072\n"` | through environment variables |
 | longpolling.enabled | bool | `false` | enable a separate longpolling instance, both web and longpolling must be enabled |
 | longpolling.extraContainers | list | `[]` | optional extra containers |
 | longpolling.extraEnv | list | `[]` | optional extra environment variables |
@@ -79,7 +81,7 @@ $ helm install my-release glodo/odoo -f ./helm-values.yaml
 | persistence.size | string | `"100Gi"` |  |
 | persistence.storageClassName | string | `"nfs-client"` |  |
 | queue.affinity | object | `{}` |  |
-| queue.config | string | `"[options]\nserver_wide_modules = queue_job,web\nworkers = 2\nmax_cron_threads = 1\nlimit_memory_soft = 3758096384\nlimit_memory_hard = 4294967296\nlimit_time_cpu = 14400\nlimit_time_real = 14400\nlimit_time_real_cron = 14400\n"` |  |
+| queue.config | string | `"[options]\nserver_wide_modules = queue_job,web\nworkers = 2\nmax_cron_threads = 1\nlimit_time_cpu = 14400\nlimit_time_real = 14400\nlimit_time_real_cron = 14400\n"` |  |
 | queue.enabled | bool | `false` | enable a second deployment, specifically running oca/queue_job |
 | queue.extraContainers | list | `[]` | optional extra containers |
 | queue.extraEnv | list | `[]` | optional extra environment variables |
@@ -122,7 +124,7 @@ $ helm install my-release glodo/odoo -f ./helm-values.yaml
 | web.certificate.issuerRef.kind | string | `"ClusterIssuer"` |  |
 | web.certificate.issuerRef.name | string | `"letsencrypt"` |  |
 | web.certificate.secretName | string | `"odoo-web"` |  |
-| web.config | string | `"[options]\nlimit_memory_soft = 3758096384\nlimit_memory_hard = 4294967296\nlimit_time_cpu = 360\nlimit_time_real = 360\nlimit_time_real_cron = 360\nmax_cron_threads = 1\nworkers = 5\nlongpolling_port = 8072\n"` | through environment variables |
+| web.config | string | `"[options]\nlimit_time_cpu = 360\nlimit_time_real = 360\nlimit_time_real_cron = 360\nmax_cron_threads = 1\nworkers = 4\n"` | through environment variables |
 | web.dns.enabled | bool | `false` | enables external-dns CRD (DNSEndpoint) creation |
 | web.dns.endPoints | list | `[]` | must be DNSEndpoint compatible As of time of writing only A, CNAME, TXT and SRV records are supported See: https://github.com/ytsarev/external-dns/blob/master/endpoint/endpoint.go#L27-L36 ```yaml - dnsName: "something.domain"   recordTTL: 60   recordType: A   targets:     - xx.xx.xx.xx ``` |
 | web.enabled | bool | `true` | enable Odoo web worker |

--- a/charts/odoo/templates/NOTES.txt
+++ b/charts/odoo/templates/NOTES.txt
@@ -1,0 +1,16 @@
+Thank you for installing {{ .Chart.Name }}.
+
+Your release is named {{ .Release.Name }}.
+
+{{- if and .Values.web.enabled .Values.web.ingress.enabled (eq .Values.web.ingress.type "IngressRoute") }}
+It is now our intention to deprecate Traefik support within this chart.
+This means that we will be looking to remove any Traefik specific resources,
+including, but not limited to:
+  - IngressRoute
+  - Middleware
+
+You *must* start considering the migration process. It is our intention to
+remove Traefik CRD after 6 months.
+
+For more information on the why, please take a look at https://github.com/GlodoUK/helm-charts/issues/48.
+{{- end }}

--- a/charts/odoo/templates/_helpers.tpl
+++ b/charts/odoo/templates/_helpers.tpl
@@ -213,3 +213,15 @@ longpolling Selector labels
 component: {{ .Values.longpolling.name | quote }}
 {{ include "odoo.common.selectorLabels" . }}
 {{- end }}
+
+{{/*
+install fullname
+*/}}
+{{- define "odoo.install.fullname" -}}
+{{- if .Values.install.fullnameOverride }}
+{{- .Values.install.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- printf "%s-%s" $name .Values.install.name | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+{{- end }}

--- a/charts/odoo/templates/install/install.yaml
+++ b/charts/odoo/templates/install/install.yaml
@@ -1,0 +1,42 @@
+{{ if and .Values.install .Values.install.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "odoo.install.fullname" . }}
+  labels:
+    {{- include "odoo.common.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": "post-install"
+    "helm.sh/hook-delete-policy": "hook-succeeded"
+    "helm.sh/hook-weight": "5"
+spec:
+  template:
+    metadata:
+      name: {{ include "odoo.install.fullname" . }}
+      labels:
+        {{- include "odoo.common.labels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      restartPolicy: Never
+      containers:
+      - name: {{ include "odoo.install.fullname" . }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default "latest" }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        env: {{- include "odoo.common.env" . | nindent 10 }}
+        command:
+          - "/bin/bash"
+        args:
+          - "-c"
+          - |
+            /opt/odoo/common/entrypoint
+            if [ "$( psql -XtAc "SELECT 1 FROM pg_database WHERE datname='$PGDATABASE'" )" != '1' ] || [ "$( psql -XtAc "SELECT count(*) FROM pg_catalog.pg_tables WHERE tablename = 'ir_module_module'" )" != '1' ]
+            then
+              echo "Database does not exist, or is blank, attempting init."
+              odoo -i base -d $PGDATABASE --no-http --stop-after-init
+            else
+              echo "Skipping database init"
+            fi
+{{ end }}

--- a/charts/odoo/templates/web/ingress.yaml
+++ b/charts/odoo/templates/web/ingress.yaml
@@ -42,7 +42,7 @@ spec:
             {{- end }}
             port:
               number: 8072
-        path: /longpolling/
+        path: {{ .Values.web.ingress.geventPath }}
         pathType: Prefix
   {{- end }}
 

--- a/charts/odoo/templates/web/ingressroute.yaml
+++ b/charts/odoo/templates/web/ingressroute.yaml
@@ -28,7 +28,7 @@ spec:
     services:
     - name: {{ $fullname }}
       port: 8069
-  - match: ({{ .Values.web.ingress.match }}) && PathPrefix(`/longpolling/`)
+  - match: ({{ .Values.web.ingress.match }}) && PathPrefix(`{{ .Values.web.ingress.geventPath }}`)
     kind: Rule
     middlewares:
       {{- range .Values.web.ingress.middlewares }}

--- a/charts/odoo/values.yaml
+++ b/charts/odoo/values.yaml
@@ -148,6 +148,9 @@ web:
       secretName: ""
       certResolver: "letsencrypt"
 
+    # -- "longpolling" path. Under 16.0 this should be changed for /websocket
+    geventPath: "/longpolling/"
+
   livenessProbe:
     # -- enable livenessProbe
     enabled: false

--- a/charts/odoo/values.yaml
+++ b/charts/odoo/values.yaml
@@ -75,14 +75,11 @@ web:
   # -- through environment variables
   config: |
     [options]
-    limit_memory_soft = 3758096384
-    limit_memory_hard = 4294967296
     limit_time_cpu = 360
     limit_time_real = 360
     limit_time_real_cron = 360
     max_cron_threads = 1
-    workers = 5
-    longpolling_port = 8072
+    workers = 4
 
   replicaCount: 1
   service:
@@ -223,13 +220,11 @@ longpolling:
   # -- through environment variables
   config: |
     [options]
-    limit_memory_soft = 3758096384
-    limit_memory_hard = 4294967296
     limit_time_cpu = 360
     limit_time_real = 360
     limit_time_real_cron = 360
     max_cron_threads = 0
-    workers = 5
+    workers = 4
     longpolling_port = 8072
 
   replicaCount: 1
@@ -312,8 +307,6 @@ queue:
     server_wide_modules = queue_job,web
     workers = 2
     max_cron_threads = 1
-    limit_memory_soft = 3758096384
-    limit_memory_hard = 4294967296
     limit_time_cpu = 14400
     limit_time_real = 14400
     limit_time_real_cron = 14400
@@ -360,6 +353,11 @@ queue:
     # readOnlyRootFilesystem: true
     # runAsNonRoot: true
     # runAsUser: 1
+
+install:
+  # -- enable the pre-install hook to init the db
+  enabled: false
+  name: "install"
 
 upgrade:
   # -- enable click-odoo-update on helm chart upgrade


### PR DESCRIPTION
## Description

- Adds support for 16.0 via a configurable longpolling path. Will default to current pre-16.0 functionality of `/longpolling/`. For 16.0 a manual change will need to be made.
- Adds a post-install helm hook to attempt to safely init the DB

Fixes T6730, #45, #47, #27

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update