### PR TITLE
feat(odoo): secrets, install hook fixes, annotations

### DIFF
--- a/charts/odoo/README.md
+++ b/charts/odoo/README.md
@@ -29,18 +29,24 @@ $ helm install my-release glodo/odoo -f ./helm-values.yaml
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| config.adminPassword | string | `""` | sets odoo configuration admin_password |
+| config.adminPassword | string | `""` | sets odoo configuration admin_password, it is not recommend to use this key |
 | config.dbFilter | string | `".*"` | sets odoo configuration db_filter |
 | config.listDB | string | `"true"` | sets odoo configuration list_db |
 | config.postgresql.database | string | `""` | sets both odoo configuration PGDATABASE, if you are setting this, you probably waant to also set config.dbFilter |
 | config.postgresql.host | string | `""` | sets both odoo configuration db_host and environment variable PGHOST |
 | config.postgresql.password | string | `""` | sets both odoo configuration db_password and environment variable PGPASSWORD |
 | config.postgresql.port | int | `5432` | sets both odoo configuration db_port and environment variable PGPORT |
+| config.postgresql.secretRef.keys | object | `{"password":"password","user":"username"}` | format 'helm value: secret key name' |
+| config.postgresql.secretRef.name | string | `""` | if set this secret's keys will be used preferentially |
 | config.postgresql.user | string | `""` | sets both odoo configuration db_username and environment variable PGUSER |
 | config.proxyMode | string | `"true"` | sets odoo configuration proxy_mode |
+| config.secretRef.keys.adminPassword | string | `"password"` |  |
+| config.secretRef.name | string | `""` | if set this secret's keys will be used preferentially |
 | config.smtp.host | string | `"false"` | sets odoo configuration smtp_server |
 | config.smtp.password | string | `"false"` | sets odoo configuration smtp_password |
 | config.smtp.port | string | `"false"` | sets odoo configuration smtp_port |
+| config.smtp.secretRef.keys | object | `{"password":"password","user":"username"}` | key presents one of the above values (user, password), value represents secret key |
+| config.smtp.secretRef.name | string | `""` | if set this secret's keys will be used preferentially |
 | config.smtp.ssl | string | `"false"` | sets odoo configuration smtp_ssl |
 | config.smtp.user | string | `"false"` | sets odoo configuration smtp_user |
 | config.withoutDemo | string | `"true"` | sets odoo configuration without_demo |

--- a/charts/odoo/templates/_helpers.tpl
+++ b/charts/odoo/templates/_helpers.tpl
@@ -36,20 +36,74 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Common envars
 */}}
 {{- define "odoo.common.env" -}}
-{{- range list "PGHOST" "PGPORT" "PGUSER" "PGDATABASE" "PROXY_MODE" "WITHOUT_DEMO" "SMTP_SERVER" "SMTP_PORT" "SMTP_USER" "SMTP_SSL" "LIST_DB" }}
+{{- range list "PGHOST" "PGPORT" "PGDATABASE" "PROXY_MODE" "WITHOUT_DEMO" "SMTP_SERVER" "SMTP_PORT" "SMTP_SSL" "LIST_DB" }}
 - name: {{ . }}
   valueFrom:
     configMapKeyRef:
       name: {{ include "odoo.config.fullname" $ }}
       key: {{ . }}
 {{- end }}
-{{- range list "PGPASSWORD" "ADMIN_PASSWORD" "SMTP_PASSWORD" }}
-- name: {{ . }}
+
+- name: "ADMIN_PASSWORD"
   valueFrom:
+    {{- if and .Values.config.secretRef .Values.config.secretRef.name .Values.config.secretRef.keys (hasKey .Values.config.secretRef.keys "adminPassword") }}
+    secretKeyRef:
+      name: {{ .Values.config.secretRef.name }}
+      key: {{ .Values.config.secretRef.keys.adminPassword }}
+    {{- else }}
     secretKeyRef:
       name: {{ include "odoo.secret.fullname" $ }}
-      key: {{ . }}
-{{- end }}
+      key: "ADMIN_PASSWORD"
+    {{- end }}
+
+- name: "PGUSER"
+  valueFrom:
+    {{- if and .Values.config.postgresql.secretRef .Values.config.postgresql.secretRef.name .Values.config.postgresql.secretRef.keys (hasKey .Values.config.postgresql.secretRef.keys "user") }}
+    secretKeyRef:
+      name: {{ .Values.config.postgresql.secretRef.name }}
+      key: {{ .Values.config.postgresql.secretRef.keys.user }}
+    {{- else }}
+    configMapKeyRef:
+      name: {{ include "odoo.config.fullname" $ }}
+      key: "PGUSER"
+    {{- end }}
+
+- name: "PGPASSWORD"
+  valueFrom:
+    {{- if and .Values.config.postgresql.secretRef .Values.config.postgresql.secretRef.name .Values.config.postgresql.secretRef.keys (hasKey .Values.config.postgresql.secretRef.keys "password") }}
+    secretKeyRef:
+      name: {{ .Values.config.postgresql.secretRef.name }}
+      key: {{ .Values.config.postgresql.secretRef.keys.password }}
+    {{- else }}
+    secretKeyRef:
+      name: {{ include "odoo.secret.fullname" $ }}
+      key: "PGPASSWORD"
+    {{- end }}
+
+- name: "SMTP_USER"
+  valueFrom:
+    {{- if and .Values.config.smtp.secretRef .Values.config.smtp.secretRef.name .Values.config.smtp.secretRef.keys (hasKey .Values.config.smtp.secretRef.keys "user") }}
+    secretKeyRef:
+      name: {{ .Values.config.smtp.secretRef.name }}
+      key: {{ .Values.config.smtp.secretRef.keys.user }}
+    {{- else }}
+    configMapKeyRef:
+      name: {{ include "odoo.config.fullname" $ }}
+      key: "SMTP_USER"
+    {{- end }}
+
+- name: "SMTP_PASSWORD"
+  valueFrom:
+    {{- if and .Values.config.smtp.secretRef .Values.config.smtp.secretRef.name .Values.config.smtp.secretRef.keys (hasKey .Values.config.smtp.secretRef.keys "password") }}
+    secretKeyRef:
+      name: {{ .Values.config.smtp.secretRef.name }}
+      key: {{ .Values.config.smtp.secretRef.keys.password }}
+    {{- else }}
+    secretKeyRef:
+      name: {{ include "odoo.secret.fullname" $ }}
+      key: "SMTP_PASSWORD"
+    {{- end }}
+
 {{- if .Values.config.dbFilter }}
 - name: DB_FILTER
   valueFrom:

--- a/charts/odoo/templates/configmap.yaml
+++ b/charts/odoo/templates/configmap.yaml
@@ -7,13 +7,17 @@ metadata:
 data:
   PGHOST: {{ .Values.config.postgresql.host | quote }}
   PGPORT: {{ .Values.config.postgresql.port | quote }}
+  {{- if not (and .Values.config.postgresql.secretRef .Values.config.postgresql.secretRef.name .Values.config.postgresql.secretRef.keys (hasKey .Values.config.postgresql.secretRef.keys "user")) }}
   PGUSER: {{ .Values.config.postgresql.user | quote }}
+  {{- end }}
   PGDATABASE: {{ .Values.config.postgresql.database | quote }}
   PROXY_MODE: {{ .Values.config.proxyMode | quote }}
   WITHOUT_DEMO: {{ .Values.config.withoutDemo | quote }}
   SMTP_SERVER: {{ .Values.config.smtp.host | quote }}
   SMTP_PORT: {{ .Values.config.smtp.port | quote }}
+  {{- if not (and .Values.config.smtp.secretRef .Values.config.smtp.secretRef.name .Values.config.smtp.secretRef.keys (hasKey .Values.config.smtp.secretRef.keys "user")) }}
   SMTP_USER: {{ .Values.config.smtp.user | quote }}
+  {{- end }}
   SMTP_SSL: {{ .Values.config.smtp.ssl | quote }}
   LIST_DB: {{ .Values.config.listDB | quote }}
   {{- if .Values.config.dbFilter }}

--- a/charts/odoo/templates/install/install.yaml
+++ b/charts/odoo/templates/install/install.yaml
@@ -7,7 +7,6 @@ metadata:
     {{- include "odoo.common.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": "post-install"
-    "helm.sh/hook-delete-policy": "hook-succeeded"
     "helm.sh/hook-weight": "5"
 spec:
   template:
@@ -39,4 +38,16 @@ spec:
             else
               echo "Skipping database init"
             fi
+        volumeMounts:
+          - name: odoo-data
+            mountPath: /var/lib/odoo
+      volumes:
+        - name: odoo-data
+          {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.existingClaim | default (include "odoo.persistence.fullname" .) }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+
 {{ end }}

--- a/charts/odoo/templates/longpolling/deployment.yaml
+++ b/charts/odoo/templates/longpolling/deployment.yaml
@@ -21,6 +21,8 @@ spec:
         {{- if .Values.rollme }}
         rollme: {{ randAlphaNum 5 | quote }}
         {{- end }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
       labels:
         {{- include "odoo.longpolling.selectorLabels" . | nindent 8 }}
     spec:

--- a/charts/odoo/templates/queue/deployment.yaml
+++ b/charts/odoo/templates/queue/deployment.yaml
@@ -21,6 +21,8 @@ spec:
         {{- if .Values.rollme }}
         rollme: {{ randAlphaNum 5 | quote }}
         {{- end }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
       labels:
         {{- include "odoo.queue.selectorLabels" . | nindent 8 }}
     spec:

--- a/charts/odoo/templates/secret.yaml
+++ b/charts/odoo/templates/secret.yaml
@@ -1,3 +1,7 @@
+{{- $setPgPassword := not (and .Values.config.postgresql.secretRef .Values.config.postgresql.secretRef.name .Values.config.postgresql.secretRef.keys (hasKey .Values.config.postgresql.secretRef.keys "password")) }}
+{{- $setAdminPassword := not (and .Values.config.secretRef .Values.config.secretRef.name .Values.config.secretRef.keys (hasKey .Values.config.secretRef.keys "adminPassword")) }}
+{{- $setSmtpPassword := not (and .Values.config.smtp.secretRef .Values.config.smtp.secretRef.name .Values.config.smtp.secretRef.keys (hasKey .Values.config.smtp.secretRef.keys "password")) }}
+{{- if or $setPgPassword $setAdminPassword $setSmtpPassword }}
 apiVersion: v1
 kind: Secret
 type: Opaque
@@ -6,6 +10,13 @@ metadata:
   labels:
     {{- include "odoo.common.labels" . | nindent 4 }}
 data:
+  {{- if $setPgPassword }}
   PGPASSWORD: {{ .Values.config.postgresql.password | b64enc | quote }}
+  {{- end }}
+  {{- if $setAdminPassword }}
   ADMIN_PASSWORD: {{ .Values.config.adminPassword | b64enc | quote }}
+  {{- end }}
+  {{- if $setSmtpPassword }}
   SMTP_PASSWORD: {{ .Values.config.smtp.password | b64enc | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/odoo/templates/upgrade/upgrade.yaml
+++ b/charts/odoo/templates/upgrade/upgrade.yaml
@@ -39,4 +39,16 @@ spec:
             else
               echo "Database $PGDATABASE does not exist, skipping click-odoo-upgrade"
             fi
+        volumeMounts:
+          - name: odoo-data
+            mountPath: /var/lib/odoo
+      volumes:
+        - name: odoo-data
+          {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.existingClaim | default (include "odoo.persistence.fullname" .) }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+
 {{ end }}

--- a/charts/odoo/templates/web/deployment.yaml
+++ b/charts/odoo/templates/web/deployment.yaml
@@ -21,6 +21,8 @@ spec:
         {{- if .Values.rollme }}
         rollme: {{ randAlphaNum 5 | quote }}
         {{- end }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
       labels:
         {{- include "odoo.web.selectorLabels" . | nindent 8 }}
     spec:

--- a/charts/odoo/values.yaml
+++ b/charts/odoo/values.yaml
@@ -27,8 +27,13 @@ config:
   listDB: "true"
   # -- sets odoo configuration db_filter
   dbFilter: ".*"
-  # -- sets odoo configuration admin_password
+  # -- sets odoo configuration admin_password, it is not recommend to use this key
   adminPassword: ""
+  secretRef:
+    # -- if set this secret's keys will be used preferentially
+    name: ""
+    keys:
+      adminPassword: "password"
 
   postgresql:
     # -- sets both odoo configuration db_host and environment variable PGHOST
@@ -39,9 +44,15 @@ config:
     password: ""
     # -- sets both odoo configuration db_port and environment variable PGPORT
     port: 5432
-    # -- sets both odoo configuration PGDATABASE, if you are setting this, you
-    # probably waant to also set config.dbFilter
+    # -- sets both odoo configuration PGDATABASE, if you are setting this, you probably waant to also set config.dbFilter
     database: ""
+    secretRef:
+      # -- if set this secret's keys will be used preferentially
+      name: ""
+      # -- format 'helm value: secret key name'
+      keys:
+        user: "username"
+        password: "password"
 
   smtp:
     # -- sets odoo configuration smtp_server
@@ -54,6 +65,13 @@ config:
     password: "false"
     # -- sets odoo configuration smtp_ssl
     ssl: "false"
+    secretRef:
+      # -- if set this secret's keys will be used preferentially
+      name: ""
+      # -- key presents one of the above values (user, password), value represents secret key
+      keys:
+        user: "username"
+        password: "password"
 
 persistence:
   # -- enable /var/lib/odoo persistence, without persistence it will be temporary - and that's a bad thing!


### PR DESCRIPTION
## Description

- adds support for externally managed secrets for critical items that probably should not just be in the helm chart - fixes #41 - disabled by default for backwards compatibility
- ensures that `install` has PVC present - fixes #52
- adds checksum annotations to deployments to enable automatic rolling if necessary

Fixes T7847
Associated risk level medium

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

