### PR TITLE
fix(odoo): ensure that deployments automatically roll when configmap and secret change, ensure that install and upgrade jobs have storage mounted

### DIFF
--- a/charts/odoo/templates/install/install.yaml
+++ b/charts/odoo/templates/install/install.yaml
@@ -39,6 +39,9 @@ spec:
             else
               echo "Skipping database init"
             fi
+        volumeMounts:
+          - name: odoo-data
+            mountPath: /var/lib/odoo
       {{- with .Values.install.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -51,4 +54,13 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      volumes:
+        - name: odoo-data
+          {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.existingClaim | default (include "odoo.persistence.fullname" .) }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+
 {{ end }}

--- a/charts/odoo/templates/longpolling/deployment.yaml
+++ b/charts/odoo/templates/longpolling/deployment.yaml
@@ -21,6 +21,8 @@ spec:
         {{- if .Values.rollme }}
         rollme: {{ randAlphaNum 5 | quote }}
         {{- end }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
       labels:
         {{- include "odoo.longpolling.selectorLabels" . | nindent 8 }}
     spec:

--- a/charts/odoo/templates/queue/deployment.yaml
+++ b/charts/odoo/templates/queue/deployment.yaml
@@ -21,6 +21,8 @@ spec:
         {{- if .Values.rollme }}
         rollme: {{ randAlphaNum 5 | quote }}
         {{- end }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
       labels:
         {{- include "odoo.queue.selectorLabels" . | nindent 8 }}
     spec:

--- a/charts/odoo/templates/upgrade/upgrade.yaml
+++ b/charts/odoo/templates/upgrade/upgrade.yaml
@@ -39,6 +39,9 @@ spec:
             else
               echo "Database $PGDATABASE does not exist, skipping click-odoo-upgrade"
             fi
+        volumeMounts:
+          - name: odoo-data
+            mountPath: /var/lib/odoo
       {{- with .Values.upgrade.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -51,4 +54,12 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      volumes:
+        - name: odoo-data
+          {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.existingClaim | default (include "odoo.persistence.fullname" .) }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
 {{ end }}

--- a/charts/odoo/templates/web/deployment.yaml
+++ b/charts/odoo/templates/web/deployment.yaml
@@ -21,6 +21,8 @@ spec:
         {{- if .Values.rollme }}
         rollme: {{ randAlphaNum 5 | quote }}
         {{- end }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
       labels:
         {{- include "odoo.web.selectorLabels" . | nindent 8 }}
     spec:


### PR DESCRIPTION
## Description

- Ensure that deployment automatically restart when configmap and secret change by storing the checksum of the relevant items
- Ensure that install and upgrade jobs have the filestore correctly mounted

Associated risk level low

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update