### PR TITLE
fix(odoo): extraManifests was broken and didn't follow general conventions

### DIFF
--- a/charts/odoo/README.md
+++ b/charts/odoo/README.md
@@ -44,7 +44,7 @@ $ helm install my-release glodo/odoo -f ./helm-values.yaml
 | config.smtp.ssl | string | `"false"` | sets odoo configuration smtp_ssl |
 | config.smtp.user | string | `"false"` | sets odoo configuration smtp_user |
 | config.withoutDemo | string | `"true"` | sets odoo configuration without_demo |
-| extraManifests | string | `""` | Use extraManifests (string) to add. This is run through the templating system, and may be useful to create custom additional deployments, statefulsets, etc. that need a "rollme" annotation changed to force redeployment after changes are made. |
+| extraManifests | list | `[]` | Use extraManifests (list) to add |
 | image.pullPolicy | string | `"IfNotPresent"` | container pullPolicy |
 | image.repository | string | `"glodouk/CHANGEME"` | container image |
 | image.tag | string | `""` | container tag |

--- a/charts/odoo/templates/extra.yaml
+++ b/charts/odoo/templates/extra.yaml
@@ -1,3 +1,4 @@
-{{- if .Values.extraManifests }}
-{{ tpl .Values.extraManifests }}
-{{- end }}
+{{ range .Values.extraManifests }}
+---
+{{ tpl (toYaml .) $ }}
+{{ end }}

--- a/charts/odoo/values.yaml
+++ b/charts/odoo/values.yaml
@@ -399,8 +399,8 @@ upgrade:
   # -- customisable arguments for click-odoo-update
   clickArgs: "--ignore-core-addons"
 
-# -- Use extraManifests (string) to add. This is run through the templating system, and may be useful to create custom additional deployments, statefulsets, etc. that need a "rollme" annotation changed to force redeployment after changes are made.
-extraManifests: ""
+# -- Use extraManifests (list) to add
+extraManifests: []
 
 velero:
   # -- enable creation of velero schedule


### PR DESCRIPTION
## Description

`extraManifests` key did not follow general conventions, and would only work with a single manifest.

As it was never in use within Glo, I'm going to assume it was never in use anywhere. This is 100% a breaking change.

Associated risk level low

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
