### PR TITLE
fix!(odoo): remove default storageClassName of nfs-client, fixes #55

### DIFF
--- a/charts/odoo/README.md
+++ b/charts/odoo/README.md
@@ -82,7 +82,7 @@ $ helm install my-release glodo/odoo -f ./helm-values.yaml
 | persistence.existingClaim | string | `""` |  |
 | persistence.name | string | `"storage"` |  |
 | persistence.size | string | `"100Gi"` |  |
-| persistence.storageClassName | string | `"nfs-client"` |  |
+| persistence.storageClassName | string | `""` |  |
 | queue.affinity | object | `{}` |  |
 | queue.config | string | `"[options]\nserver_wide_modules = queue_job,web\nworkers = 2\nmax_cron_threads = 1\nlimit_time_cpu = 14400\nlimit_time_real = 14400\nlimit_time_real_cron = 14400\n"` |  |
 | queue.enabled | bool | `false` | enable a second deployment, specifically running oca/queue_job |

--- a/charts/odoo/values.yaml
+++ b/charts/odoo/values.yaml
@@ -59,7 +59,7 @@ persistence:
   # -- enable /var/lib/odoo persistence, without persistence it will be temporary - and that's a bad thing!
   enabled: true
   name: "storage"
-  storageClassName: "nfs-client"
+  storageClassName: ""
   existingClaim: ""
   annotations: {}
   # -- when running deployment with replicas > 1 ReadWriteMany is a requirement, if you are in an environment without ReadWriteMany available then you will need to find an alternative solution i.e. https://github.com/camptocamp/odoo-cloud-platform/tree/14.0/base_attachment_object_storage


### PR DESCRIPTION
## Description

Long overdue removal/change of the default value of `storageClassName` for the Odoo persistence.

Fixes #55.

This was previously announced in #24 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

